### PR TITLE
Tell zbarimg to expect a QRCode

### DIFF
--- a/qr2asc.sh
+++ b/qr2asc.sh
@@ -43,7 +43,7 @@ for img in "$@"; do
 	fi
 	asc_key="${tmp_file}.${index}"
 	echo "decoding ${img}"
-    chunk=$( zbarimg --raw -Sdisable -Sqrcode.enable ${img} 2>/dev/null )
+    chunk=$( zbarimg --raw --set disable --set qrcode.enable ${img} 2>/dev/null )
 	if [ $? -ne 0 ]; then
 		echo "failed to decode QR image"
 		exit 2

--- a/qr2asc.sh
+++ b/qr2asc.sh
@@ -52,7 +52,7 @@ for img in "$@"; do
 	fi
 	asc_key="${tmp_file}.${index}"
 	echo "decoding ${img}"
-    chunk=$( zbarimg --raw ${img} 2>/dev/null | perl -p -e 'chomp if eof' )
+    chunk=$( zbarimg --raw -Sdisable -Sqrcode.enable ${img} 2>/dev/null )
 	if [ $? -ne 0 ]; then
 		echo "failed to decode QR image"
 		exit 2


### PR DESCRIPTION
We are telling zbarimg to expect only qrcode type symbols. There should only be output for qrcode, so there should not be newlines with different decode outputs (perl code no longer needed).

This reduces the perl dependency and is more explicit. This should result in increased robustness.
